### PR TITLE
Add TimeReport MCP example

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,38 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.example</groupId>
+    <artifactId>mcp-demo</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <name>TimeReportMCP Demo</name>
+
+    <properties>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.9.3</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.1.0</version>
+                <configuration>
+                    <useModulePath>false</useModulePath>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/main/java/com/example/mcp/TimeReportEntry.java
+++ b/src/main/java/com/example/mcp/TimeReportEntry.java
@@ -1,0 +1,19 @@
+package com.example.mcp;
+
+public class TimeReportEntry {
+    private final String signature;
+    private final int hours;
+
+    public TimeReportEntry(String signature, int hours) {
+        this.signature = signature;
+        this.hours = hours;
+    }
+
+    public String getSignature() {
+        return signature;
+    }
+
+    public int getHours() {
+        return hours;
+    }
+}

--- a/src/main/java/com/example/mcp/TimeReportMCP.java
+++ b/src/main/java/com/example/mcp/TimeReportMCP.java
@@ -1,0 +1,33 @@
+package com.example.mcp;
+
+import java.time.YearMonth;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Simple implementation of a model context protocol (MCP) for time report statistics.
+ */
+public class TimeReportMCP {
+
+    private final Map<YearMonth, List<TimeReportEntry>> data = new HashMap<>();
+
+    public TimeReportMCP() {
+        // load fixtures
+        List<TimeReportEntry> entries = new ArrayList<>();
+        entries.add(new TimeReportEntry("NH", 80));
+        data.put(YearMonth.of(2025, 5), entries);
+    }
+
+    /**
+     * Returns the time report statistics for the given year and month.
+     *
+     * @param year  the year
+     * @param month the month (1-based, January is 1)
+     * @return list of time report entries
+     */
+    public List<TimeReportEntry> getTimeReportStats(int year, int month) {
+        return data.getOrDefault(YearMonth.of(year, month), new ArrayList<>());
+    }
+}

--- a/src/test/java/com/example/mcp/TimeReportMCPTest.java
+++ b/src/test/java/com/example/mcp/TimeReportMCPTest.java
@@ -1,0 +1,20 @@
+package com.example.mcp;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+public class TimeReportMCPTest {
+
+    @Test
+    public void testFixture() {
+        TimeReportMCP mcp = new TimeReportMCP();
+        List<TimeReportEntry> entries = mcp.getTimeReportStats(2025, 5);
+        assertEquals(1, entries.size());
+        TimeReportEntry entry = entries.get(0);
+        assertEquals("NH", entry.getSignature());
+        assertEquals(80, entry.getHours());
+    }
+}


### PR DESCRIPTION
## Summary
- add Maven project and java code implementing a simple TimeReport MCP
- include a fixture for 2025-05 with signature `NH` and `80` hours
- provide a unit test verifying the fixture

## Testing
- `mvn -q test` *(fails: `mvn` not found)*