### PR TITLE
Add search endpoint

### DIFF
--- a/src/main/java/com/example/mcp/SearchMCP.java
+++ b/src/main/java/com/example/mcp/SearchMCP.java
@@ -1,0 +1,33 @@
+package com.example.mcp;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Very small MCP providing search results for demonstration purposes.
+ */
+public class SearchMCP {
+
+    private final List<SearchResult> fixtures = new ArrayList<>();
+
+    public SearchMCP() {
+        fixtures.add(new SearchResult("1", "Time Report Overview",
+                "Overview of the TimeReport MCP demo.", null));
+    }
+
+    /**
+     * Returns search results for the given query. The implementation simply
+     * returns the fixture list when the query is not blank and contains either
+     * 'time' or 'report'. Otherwise an empty list is returned.
+     */
+    public List<SearchResult> search(String query) {
+        if (query == null) {
+            return new ArrayList<>();
+        }
+        String q = query.toLowerCase();
+        if (q.contains("time") || q.contains("report")) {
+            return new ArrayList<>(fixtures);
+        }
+        return new ArrayList<>();
+    }
+}

--- a/src/main/java/com/example/mcp/SearchResult.java
+++ b/src/main/java/com/example/mcp/SearchResult.java
@@ -1,0 +1,34 @@
+package com.example.mcp;
+
+/**
+ * Simple search result data object used by the search MCP.
+ */
+public class SearchResult {
+    private final String id;
+    private final String title;
+    private final String text;
+    private final String url;
+
+    public SearchResult(String id, String title, String text, String url) {
+        this.id = id;
+        this.title = title;
+        this.text = text;
+        this.url = url;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public String getText() {
+        return text;
+    }
+
+    public String getUrl() {
+        return url;
+    }
+}

--- a/src/test/java/com/example/mcp/SearchMCPServerTest.java
+++ b/src/test/java/com/example/mcp/SearchMCPServerTest.java
@@ -1,0 +1,45 @@
+package com.example.mcp;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.URL;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/** Simple tests for the search endpoint. */
+public class SearchMCPServerTest {
+    private TimeReportMCPServer server;
+
+    @BeforeEach
+    public void setUp() throws IOException {
+        server = new TimeReportMCPServer(0);
+        server.start();
+    }
+
+    @AfterEach
+    public void tearDown() {
+        server.stop(0);
+    }
+
+    @Test
+    public void testSearchEndpoint() throws Exception {
+        String url = "http://localhost:" + server.getPort() + "/search?query=time";
+        HttpURLConnection conn = (HttpURLConnection) new URL(url).openConnection();
+        conn.setRequestMethod("GET");
+        assertEquals(200, conn.getResponseCode());
+        BufferedReader reader = new BufferedReader(new InputStreamReader(conn.getInputStream()));
+        StringBuilder sb = new StringBuilder();
+        String line;
+        while ((line = reader.readLine()) != null) {
+            sb.append(line);
+        }
+        String body = sb.toString();
+        assertTrue(body.contains("\"results\""));
+    }
+}


### PR DESCRIPTION
## Summary
- implement minimal SearchMCP and SearchResult
- extend server with `/search` endpoint
- list search endpoint in manifest
- test new endpoint

## Testing
- `./run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_b_684a96a1a7708322bce352f592828fa2