### PR TITLE
Move demo server endpoints under /sse path

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,12 +28,12 @@ Alternatively you can run the class directly from your IDE or the compiled class
 
 ## Endpoints
 
-This demonstration exposes two HTTP endpoints:
+This demonstration exposes two HTTP endpoints under the `/sse` path:
 
 | Endpoint | Method | Description |
 |----------|--------|-------------|
-| `/.well-known/mcp.json` | `GET` | Returns a JSON manifest describing the MCP implementation. |
-| `/time-report?year=YYYY&month=MM` | `GET` | Returns time report statistics for the given year and month in JSON format. |
+| `/sse/.well-known/mcp.json` | `GET` | Returns a JSON manifest describing the MCP implementation. |
+| `/sse/time-report?year=YYYY&month=MM` | `GET` | Returns time report statistics for the given year and month in JSON format. |
 
 ### Manifest format
 
@@ -43,13 +43,13 @@ The manifest endpoint returns JSON similar to:
 {
   "version": "1.0",
   "description": "TimeReport MCP endpoints",
-  "endpoints": ["/stats/{year}/{month}"]
+  "endpoints": ["/sse/time-report?year={year}&month={month}"]
 }
 ```
 
 ### Time report response
 
-Querying `/time-report` responds with an array of objects:
+Querying `/sse/time-report` responds with an array of objects:
 
 ```json
 [

--- a/src/main/java/com/example/mcp/TimeReportMCPServer.java
+++ b/src/main/java/com/example/mcp/TimeReportMCPServer.java
@@ -20,6 +20,8 @@ import java.util.stream.Stream;
  */
 public class TimeReportMCPServer {
 
+    private static final String BASE_PATH = "/sse";
+
     private final HttpServer server;
     private final TimeReportMCP mcp;
     private final SearchMCP searchMcp;
@@ -51,13 +53,13 @@ public class TimeReportMCPServer {
         this.mcp = mcp;
         this.searchMcp = searchMcp;
         server = HttpServer.create(new InetSocketAddress(port), 0);
-        server.createContext("/.well-known/mcp.json",
+        server.createContext(BASE_PATH + "/.well-known/mcp.json",
                 new LoggingHandler(new ManifestHandler()));
-        server.createContext("/time-report",
+        server.createContext(BASE_PATH + "/time-report",
                 new LoggingHandler(new TimeReportHandler()));
-        server.createContext("/search",
+        server.createContext(BASE_PATH + "/search",
                 new LoggingHandler(new SearchHandler()));
-        server.createContext("/fetch",
+        server.createContext(BASE_PATH + "/fetch",
                 new LoggingHandler(new FetchHandler()));
     }
 
@@ -104,8 +106,8 @@ public class TimeReportMCPServer {
 
             String json = "{\"version\":\"1.0\"," +
                     "\"description\":\"TimeReport MCP endpoints\"," +
-                    "\"endpoints\":[\"/time-report?year={year}&month={month}\"," +
-                    "\"/search?query={query}\"]}";
+                    "\"endpoints\":[\"" + BASE_PATH + "/time-report?year={year}&month={month}\"," +
+                    "\"" + BASE_PATH + "/search?query={query}\"]}";
 
             byte[] bytes = json.getBytes(StandardCharsets.UTF_8);
             exchange.getResponseHeaders().add("Content-Type", "application/json");

--- a/src/test/java/com/example/mcp/SearchMCPServerTest.java
+++ b/src/test/java/com/example/mcp/SearchMCPServerTest.java
@@ -29,7 +29,7 @@ public class SearchMCPServerTest {
 
     @Test
     public void testSearchEndpoint() throws Exception {
-        String url = "http://localhost:" + server.getPort() + "/search?query=time";
+        String url = "http://localhost:" + server.getPort() + "/sse/search?query=time";
         HttpURLConnection conn = (HttpURLConnection) new URL(url).openConnection();
         conn.setRequestMethod("GET");
         assertEquals(200, conn.getResponseCode());
@@ -45,7 +45,7 @@ public class SearchMCPServerTest {
 
     @Test
     public void testFetchEndpoint() throws Exception {
-        String url = "http://localhost:" + server.getPort() + "/fetch?id=1";
+        String url = "http://localhost:" + server.getPort() + "/sse/fetch?id=1";
         HttpURLConnection conn = (HttpURLConnection) new URL(url).openConnection();
         conn.setRequestMethod("GET");
         assertEquals(200, conn.getResponseCode());

--- a/src/test/java/com/example/mcp/TimeReportMCPServerTest.java
+++ b/src/test/java/com/example/mcp/TimeReportMCPServerTest.java
@@ -32,7 +32,7 @@ public class TimeReportMCPServerTest {
 
     @Test
     public void testManifestEndpoint() throws Exception {
-        String url = "http://localhost:" + server.getPort() + "/.well-known/mcp.json";
+        String url = "http://localhost:" + server.getPort() + "/sse/.well-known/mcp.json";
         HttpURLConnection conn = (HttpURLConnection) new URL(url).openConnection();
         conn.setRequestMethod("GET");
         assertEquals(200, conn.getResponseCode());


### PR DESCRIPTION
## Summary
- prefix all server endpoints with `/sse`
- update tests for new `/sse` paths
- document updated paths in README

## Testing
- `bash run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_b_684ab44149d4832282e58c898ea6d76f